### PR TITLE
ブラウザ戻る/進むのハンドル修正

### DIFF
--- a/src/frontend/js/dashboard/dashboard.js
+++ b/src/frontend/js/dashboard/dashboard.js
@@ -31,6 +31,13 @@ function dashboardEventHandlers() {
         getAchievementsButton
       );
     });
+
+    participantNameInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        getAchievementsButton.click();
+      }
+    });
+
     getAchievementsButton.addEventListener("click", (e) => {
       const url = new URL("/dashboard", window.location.origin);
       url.searchParams.append("participant_name", participantNameInput.value);
@@ -39,16 +46,13 @@ function dashboardEventHandlers() {
   }
 }
 
-dashboardEventHandlers();
-
-document.addEventListener("DOMContentLoaded", () => {
-  function init() {
-    dashboardEventHandlers();
-  }
-
-  window.addEventListener("popstate", (event) => {
-    handlePopState(event);
+function initDashboard() {
+  document.addEventListener("DOMContentLoaded", () => {
+    window.addEventListener("popstate", () => {
+      handlePopState();
+    });
     dashboardEventHandlers();
   });
-  init();
-});
+}
+
+initDashboard();

--- a/src/frontend/js/game/start.js
+++ b/src/frontend/js/game/start.js
@@ -102,14 +102,13 @@ function startEventHandlers() {
   checkStartButtonValid();
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  function init() {
-    startEventHandlers();
-  }
-
-  window.addEventListener("popstate", (event) => {
-    handlePopState(event);
+function initStart() {
+  document.addEventListener("DOMContentLoaded", () => {
+    window.addEventListener("popstate", () => {
+      handlePopState();
+    });
     startEventHandlers();
   });
-  init();
-});
+}
+
+initStart();

--- a/src/frontend/js/game/top.js
+++ b/src/frontend/js/game/top.js
@@ -17,14 +17,13 @@ function topEventHandlers() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  function init() {
-    topEventHandlers();
-  }
-  window.addEventListener("popstate", (event) => {
-    handlePopState(event);
+function initTop() {
+  document.addEventListener("DOMContentLoaded", () => {
+    window.addEventListener("popstate", () => {
+      handlePopState();
+    });
     topEventHandlers();
   });
+}
 
-  init();
-});
+initTop();

--- a/src/frontend/js/utils/router.js
+++ b/src/frontend/js/utils/router.js
@@ -17,11 +17,30 @@ function loadPage(url, callback) {
     });
 }
 
+// 戻る/進むボタンが押されたときにDOMを更新する関数
+function nonPushLoadPage(url, callback) {
+  fetch(url)
+    .then((response) => response.text())
+    .then((html) => {
+      document.getElementById("app").innerHTML = html;
+      if (callback) {
+        callback();
+      }
+    })
+    .catch((error) => {
+      console.error("Error loading the page: ", error);
+    });
+}
+
 // ブラウザの戻る/進むボタンが押されたときに発火する関数
-function handlePopState(event) {
-  if (event.state) {
-    document.getElementById("app").innerHTML = event.state.html;
-  } else {
-    location.reload();
+function handlePopState() {
+  url = window.location.pathname;
+  if (url === "/") {
+    callback = topEventHandlers;
+  } else if (url === "/start") {
+    callback = startEventHandlers;
+  } else if (url === "/dashboard") {
+    callback = dashboardEventHandlers;
   }
+  nonPushLoadPage(url, callback);
 }


### PR DESCRIPTION
#49 


## 実装したこと
- 戻る進むボタンのハンドル
- 現状戻る進むボタンでリロードしている→リロードしないかつ，イベントハンドラが正しく動作するようにする
- Dashboardの検索ボックスでEnterを押したときにも検索できるようにする