### PR TITLE
リロードの制御

### DIFF
--- a/src/frontend/js/dashboard/dashboard.js
+++ b/src/frontend/js/dashboard/dashboard.js
@@ -44,6 +44,17 @@ function dashboardEventHandlers() {
       loadPage(url, dashboardEventHandlers);
     });
   }
+
+  // reload時にtopに戻る
+  if (getAchievementsButton && participantNameInput) {
+    window.addEventListener('load', () => {
+      const perfEntries = performance.getEntriesByType("navigation");
+      const isReload = perfEntries[0].type === 'reload';
+      if (isReload) {
+        window.location.href = '/';
+      }
+    });
+  }
 }
 
 function initDashboard() {

--- a/src/frontend/js/game/pong.js
+++ b/src/frontend/js/game/pong.js
@@ -35,6 +35,17 @@ function pongEventHandlers() {
       openModal();
     });
   }
+
+  // pongの画面上でリロードした場合、トップページにリダイレクト
+  if (gameContainer) {
+    window.addEventListener('load', () => {
+      const perfEntries = performance.getEntriesByType("navigation");
+      isReload = perfEntries[0].type === 'reload';
+      if (isReload) {
+        window.location.href = '/';
+      }
+    });
+  }
 }
 
 // モーダルを開き，トーナメントを描画

--- a/src/frontend/js/game/pong.js
+++ b/src/frontend/js/game/pong.js
@@ -40,7 +40,7 @@ function pongEventHandlers() {
   if (gameContainer) {
     window.addEventListener('load', () => {
       const perfEntries = performance.getEntriesByType("navigation");
-      isReload = perfEntries[0].type === 'reload';
+      const isReload = perfEntries[0].type === 'reload';
       if (isReload) {
         window.location.href = '/';
       }

--- a/src/frontend/js/game/start.js
+++ b/src/frontend/js/game/start.js
@@ -163,6 +163,17 @@ function startEventHandlers() {
     });
   });
 
+  // reload時にtopに戻る
+  if (startGameButton) {
+    window.addEventListener('load', () => {
+      const perfEntries = performance.getEntriesByType("navigation");
+      const isReload = perfEntries[0].type === 'reload';
+      if (isReload) {
+        window.location.href = '/';
+      }
+    });
+  }
+
   checkStartButtonValid();
 }
 


### PR DESCRIPTION
#76 

## 実装したこと

リロード時にtopページにリダイレクトするように修正。基本リロードは起きないはずなので，リロードが起きたらtopに飛んで初期化する

どのページでもリロードするとtopへリダイレクトする。start→top, dashboard→top, game→top
