### PR TITLE
[フロント] dashboardフロント作成

### DIFF
--- a/src/backend/handlers/getAchievements.py
+++ b/src/backend/handlers/getAchievements.py
@@ -1,6 +1,7 @@
 # snemoto test for routing
 from django.shortcuts import render
 from models.models import Score
+from django.http import JsonResponse
 
 # def getAchievements(request):
 # 	return render(request, "getAchievements.html")
@@ -9,12 +10,15 @@ from models.models import Score
 # def getAchievements(request, participant_name):
 # 	return render(request, "getAchievements.html", {'participant_name': participant_name})
 
+def dashboard(request):
+    return render(request, "templates/dashboard.html")
+
 def getAchievements(request):
     participant_name = request.GET.get('participant_name', '')
     achievements = Score.objects.filter(participant_name=participant_name)
     achievements_list = [{'score': achievement.score, 'match_id': achievement.match_id} for achievement in achievements]
     data = {
         'participant_name': participant_name,
-        'achievements': achievements_list
+        'achievements': achievements_list,
     }
-    return render(request, "templates/dashboard.html", {'data': data})
+    return JsonResponse(data)

--- a/src/backend/server/urls.py
+++ b/src/backend/server/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.urls import path, include
 
 from handlers.getClientApp import top, start, game
-from handlers.getAchievements import getAchievements
+from handlers.getAchievements import dashboard, getAchievements
 from handlers.storeTournamentResult import storeTournamentResult, save_test
 from models.views import test_example
 from django.conf.urls import handler404
@@ -23,7 +23,8 @@ urlpatterns += i18n_patterns(
 	path('start/', start, name="start"),
 	path('gamefinish/', storeTournamentResult, name="gamefinish"),
 	# for query_paramator
-	path('dashboard/', getAchievements, name="dashboard"),
+	path('dashboard/', dashboard, name="dashboard"),
+	path('getAchievements/', getAchievements, name='getAchievements'),
 	# for path_paramator
 	# path('dashboard/<str:participant_name>/', getAchievements, name="dashboard"),
 	# path('', getClientApp, name=""),

--- a/src/frontend/base.html
+++ b/src/frontend/base.html
@@ -9,6 +9,8 @@
 <!-- bootstrap -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+<!-- chart.js -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
 
 {% load static %}
 <script src="{% static 'js/utils/class.js' %}"></script>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -36,6 +36,8 @@
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
 		integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
 		crossorigin="anonymous"></script>
+	<!-- chart.js -->
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
 
 	{% load static %}
 	<script src="{% static 'js/utils/class.js' %}"></script>

--- a/src/frontend/js/dashboard/dashboard.js
+++ b/src/frontend/js/dashboard/dashboard.js
@@ -1,3 +1,5 @@
+let chartInstance = null;
+
 function checkGetAchievementsButtonValid(input, button) {
   if (input.value.trim() !== "") {
     button.disabled = false;
@@ -41,11 +43,35 @@ function dashboardEventHandlers() {
 
     getAchievementsButton.addEventListener("click", (e) => {
       const url = new URL(
-        "/" + appState.getStateByKey("language") + "/dashboard",
+        "/" + appState.getStateByKey("language") + "/getAchievements",
         window.location.origin
       );
       url.searchParams.append("participant_name", participantNameInput.value);
-      loadPage(url, dashboardEventHandlers);
+      fetch(url)
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          const achievements = data.achievements;
+          const scores = achievements.map((achievement) => achievement.score);
+
+          // getAchievements関数にscoresを追加して仮のデータとして取得する時
+          // const scores = data.scores;
+
+          const lang = appState.getStateByKey("language");
+          let message = " 's Achievements";
+          if (lang === "ja") {
+            message = " さんの実績";
+          } else if (lang === "fr") {
+            message = " Réalisations";
+          }
+          document.getElementById("name-achievements").innerText =
+            participantNameInput.value + message;
+          drawChart(scores);
+        })
+        .catch((error) => {
+          console.error("Error getAchievements: ", error);
+        });
     });
   }
 
@@ -55,10 +81,69 @@ function dashboardEventHandlers() {
       const perfEntries = performance.getEntriesByType("navigation");
       const isReload = perfEntries[0].type === "reload";
       if (isReload) {
-        window.location.href = "/";
+        const lang = appState.getStateByKey("language");
+        window.location.href = "/" + lang + "/";
       }
     });
   }
+}
+
+function drawChart(scores) {
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+  const ctx = document.getElementById("chart");
+  const labels = Array.from({ length: 12 }, (_, i) => `${i}`);
+  const scoreCounts = Array(12).fill(0);
+  let winRatePercentage = 0;
+  if (scores.length > 0) {
+    const winRate = scores.filter((score) => score === 11).length / scores.length;
+    winRatePercentage = Math.round(winRate * 100);
+  }
+  scores.forEach((score) => {
+    if (score >= 0 && score <= 11) {
+      scoreCounts[score] += 1;
+    }
+  });
+  const data = {
+    labels: labels,
+    datasets: [
+      {
+        label: "Scores",
+        data: scoreCounts,
+        backgroundColor: [
+          "rgb(54, 162, 235)",
+          "rgb(75, 192, 192)",
+          "rgb(153, 102, 255)",
+          "rgb(255, 159, 64)",
+          "rgb(255, 205, 86)",
+          "rgb(255, 99, 71)",
+          "rgb(144, 238, 144)",
+          "rgb(173, 216, 230)",
+          "rgb(255, 182, 193)",
+          "rgb(138, 43, 226)",
+          "rgb(255, 215, 0)",
+          "rgb(255, 99, 132)",
+        ],
+        hoverOffset: 4,
+      },
+    ],
+  };
+  const config = {
+    type: "doughnut",
+    data: data,
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        title: {
+          display: true,
+          text: `Score Distribution (Win Rate: ${winRatePercentage}%)`,
+        },
+      },
+    },
+  };
+  chartInstance = new Chart(ctx, config);
 }
 
 function initDashboard() {

--- a/src/frontend/templates/dashboard.html
+++ b/src/frontend/templates/dashboard.html
@@ -21,18 +21,14 @@
       <button class="btn btn-success" id="getAchievementsButton">{% blocktranslate %}Search{% endblocktranslate %}</button>
     </div>
   </div>
-  {% if data.participant_name %}
-  <div>
-    <h1>{{ data.participant_name }}{% blocktranslate %}'s Achievements{% endblocktranslate %}</h1>
-    <ul>
-      {% for achievement in data.achievements %}
-      <li>Score {{ achievement.score }}, Match ID {{ achievement.match_id }}
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
-</div>
 
+  <div>
+    <h1 id="name-achievements"></h1>
+  </div>
+
+  <div class="mt-5 p-5">
+    <canvas id="chart" width="400" height="400"></canvas>
+  </div>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
#100 

## 実装した内容
- `/getAchievements`をjsonで返すように変更
- dashboardの表示は`/dashboard`を追加

## テスト
- データの表示はgetAchievements関数内に仮の値scoresを追加して表示
- フロント側でもscoresを直接取得するような記述を書いて取得
- 本来はachievementsの中からscoreを取りだして集計
```
'scores' : [11, 0, 1, 2, 11, 10, 10, 11, 9]
```


![image](https://github.com/ichinose9372/ft_transcendense_42/assets/89718149/8e79764b-8a18-4825-868a-419391c29a40)
　