### PR TITLE
トーナメント終了時に「game/end」ページに遷移

### DIFF
--- a/src/backend/handlers/getClientApp.py
+++ b/src/backend/handlers/getClientApp.py
@@ -13,3 +13,6 @@ def start(request):
 
 def game(request):
 	return render(request, "templates/game.html")
+
+def end_tournament_view(request):
+	return render(request, "templates/end.html")

--- a/src/backend/server/urls.py
+++ b/src/backend/server/urls.py
@@ -2,7 +2,7 @@ from sys import prefix
 from django.contrib import admin
 from django.urls import path, include
 
-from handlers.getClientApp import top, start, game
+from handlers.getClientApp import top, start, game, end_tournament_view
 from handlers.getAchievements import dashboard, getAchievements
 from handlers.storeTournamentResult import storeTournamentResult
 from models.views import test_example
@@ -30,6 +30,7 @@ urlpatterns += i18n_patterns(
 	# path('', getClientApp, name=""),
 	path('test_example/', test_example, name='test_example'),
 	path('game/', game, name='game'),
+	path('game/end/', end_tournament_view, name='end_tournament'),
 )
 
 handler404 = 'models.errors.custom_404'

--- a/src/frontend/js/game/pong.js
+++ b/src/frontend/js/game/pong.js
@@ -359,6 +359,8 @@ function updateMatchData(winner) {
       appState.setState({ matches: updatedMatchesWithParent });
     } else {
       appState.setState({ matches: updatedMatches });
+      const currentLang = window.location.pathname.split('/')[1];
+      window.location.href = `/${currentLang}/game/end?winner=${encodeURIComponent(winner)}`;
     }
   }
 }

--- a/src/frontend/locale/en/LC_MESSAGES/django.po
+++ b/src/frontend/locale/en/LC_MESSAGES/django.po
@@ -86,3 +86,6 @@ msgstr ""
 
 msgid "Rules"
 msgstr ""
+
+msgid "End Tournament"
+msgstr ""

--- a/src/frontend/locale/fr/LC_MESSAGES/django.po
+++ b/src/frontend/locale/fr/LC_MESSAGES/django.po
@@ -85,3 +85,6 @@ msgstr "Joueur de droite : ↑ (haut), ↓ (bas) pour déplacer la pagaie."
 
 msgid "Rules"
 msgstr "Règles"
+
+msgid "End Tournament"
+msgstr "Fin du tournoi"

--- a/src/frontend/locale/ja/LC_MESSAGES/django.po
+++ b/src/frontend/locale/ja/LC_MESSAGES/django.po
@@ -89,3 +89,6 @@ msgstr "右のプレイヤー: ↑ (上), ↓ (下)でパドルを動かす"
 
 msgid "Rules"
 msgstr "ルール"
+
+msgid "End Tournament"
+msgstr "トーナメント終了"

--- a/src/frontend/templates/end.html
+++ b/src/frontend/templates/end.html
@@ -1,0 +1,27 @@
+{% extends 'index.html' %} {% block content %}
+{% load i18n %}
+<div id="game-over-message"></div>
+
+<div class="content-wrapper" style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100vh;">
+  <div class="winner-message" style="width: 100%; display: flex; justify-content: center; align-items: center;">
+    <h2 id="winner-name" class="text-center" style="text-align: center; margin-top: 20px;"></h2>
+  </div>
+
+  <button id="end-tournament-button" class="btn btn-primary" style="margin-top: 20px; padding: 10px 20px; font-size: 18px; color: #fff; background-color: #555; border: none; border-radius: 5px; cursor: pointer;">{% blocktranslate %}End Tournament{% endblocktranslate %}</button>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const winner = urlParams.get('winner');
+    if (winner) {
+      document.getElementById('winner-name').textContent = `🎉 ${winner} 🎉`;
+    }
+  });
+</script>
+
+<script>
+  document.getElementById('end-tournament-button').addEventListener('click', function() {
+    window.location.href = '/';
+  });
+</script>
+  {% endblock %}


### PR DESCRIPTION
## 実装したこと
トーナメント終了後に以下の処理を実装
- /game/endに画面遷移
- 勝者名と「トーナメント終了」ボタンを表示

## イメージ
![image](https://github.com/ichinose9372/ft_transcendense_42/assets/66728424/0c4c882a-df65-450a-a51b-294a7402f58f)
